### PR TITLE
Release 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ __Contributors:__ [bjcfuller](https://github.com/bjcfuller), [alexandragauss](ht
 __Tags:__ plugins, shortcodes  
 __Requires at least:__ 5.0  
 __Tested up to:__ 6.0.2  
-__Stable tag:__ 1.2.0  
+__Stable tag:__ 1.2.1  
 __License:__ GPL-3.0  
 __Licence URI:__ https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A tool that makes it easy to embed dynamic course data from Kuali.
 
-## What's new in v1.2.0
+## What's new in v1.2.1
 
-- Adds a composer.json file
+- Changes the default course return limit to 100, which matches the Kuali API maximum.
 
 ## Example Usage
 

--- a/inc/uri-kuali-shortcodes.php
+++ b/inc/uri-kuali-shortcodes.php
@@ -18,7 +18,7 @@
     'number' => NULL,
  		'before' => '<div class="uri-kuali">',
  		'after' => '</div>',
-    'limit' => 200,
+    'limit' => 100, // 100 is the maximum Kuali will return with a single query.  For more than that, @see https://developers.kuali.co/#cm-courses,-programs,-experiences,-and-specializations-query
  	), $attributes, $shortcode );
 
  	$subject_data = uri_kuali_api_get_subject_data( $attributes['subject'] );

--- a/uri-kuali.php
+++ b/uri-kuali.php
@@ -3,7 +3,7 @@
 Plugin Name: URI Kuali
 Plugin URI: https://www.uri.edu
 Description: Implements a shortcode to display course data from Kuali's API. [courses subject="AAF"]
-Version: 1.2.0
+Version: 1.2.1
 Author: Brandon Fuller
 Author: Alexandra Gauss
 Author URI:


### PR DESCRIPTION
## What's new in v1.2.1

- Changes the default course return limit to 100, which matches the Kuali API maximum.